### PR TITLE
Litepaper flag pics now link to docs pages

### DIFF
--- a/src/pages/litepaper.js
+++ b/src/pages/litepaper.js
@@ -3,9 +3,9 @@ import "./litepaper.sass";
 import Layout from "../components/layout";
 import UiImg from "../components/UiImg";
 
-const LITEPAPER_GB = "https://www.synthetix.io/uploads/synthetix_litepaper.pdf";
-const LITEPAPER_KR = "https://www.synthetix.io/uploads/synthetix_litepaper_korean.pdf";
-const LITEPAPER_CN = "https://www.synthetix.io/uploads/synthetix_litepaper_mandarin.pdf";
+const LITEPAPER_GB = "https://docs.synthetix.io/litepaper/";
+const LITEPAPER_KR = "https://docs.synthetix.io/litepaper/korean/";
+const LITEPAPER_CN = "https://docs.synthetix.io/litepaper/chinese/";
 
 export default class LitepaperPage extends React.Component {
 	render() {


### PR DESCRIPTION
Linking to the docs rather than static PDF's will allow us to update minor changes (e.g. the recent C-Ratio change) far more easily. 